### PR TITLE
Fix for #17, plus test and connection refactor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -72,7 +72,7 @@ class Riemann::Client
 
   def connect
     # NOTE: connections are made automatically on send
-    puts "Riemann client#connect is deprecated"
+    warn "Riemann client#connect is deprecated"
   end
 
   # Close both UDP and TCP sockets.

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -76,12 +76,6 @@ class Riemann::Client
     @tcp.close
   end
 
-  # Connect both UDP and TCP sockets.
-  def connect
-    udp.connect
-    tcp.connect
-  end
-
   def connected?
     tcp.connected? and udp.connected?
   end

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -70,6 +70,11 @@ class Riemann::Client
       (response.states || [])
   end
 
+  def connect
+    # NOTE: connections are made automatically on send
+    puts "Riemann client#connect is deprecated"
+  end
+
   # Close both UDP and TCP sockets.
   def close
     @udp.close

--- a/lib/riemann/client/tcp.rb
+++ b/lib/riemann/client/tcp.rb
@@ -46,7 +46,7 @@ module Riemann
 
       def connected?
         @locket.synchronize do
-          (@socket.nil? || @socket.closed?) ? false : true
+          !@socket.nil? && !@socket.closed?
         end
       end
 

--- a/lib/riemann/client/udp.rb
+++ b/lib/riemann/client/udp.rb
@@ -37,12 +37,12 @@ module Riemann
 
       def send_maybe_recv(message)
         with_connection do |s|
-          x = message.encode ''
-          unless x.length < @max_size
+          encoded_string = message.encode.to_s
+          unless encoded_string.length < @max_size
             raise TooBig
           end
 
-          s.send(x, 0, @host, @port)
+          s.send(encoded_string, 0, @host, @port)
           nil
         end
       end

--- a/lib/riemann/message.rb
+++ b/lib/riemann/message.rb
@@ -1,7 +1,7 @@
 module Riemann
   class Message
     include Beefcake::Message
-    
+
     optional :ok, :bool, 2
     optional :error, :string, 3
     repeated :states, State, 4
@@ -9,9 +9,8 @@ module Riemann
     repeated :events, Event, 6
 
     def encode_with_length
-      buffer = ''
-      encoded = encode buffer
-      "#{[encoded.length].pack('N')}#{encoded}"
+      encoded_string = encode.to_s
+      [encoded_string.length].pack('N') << encoded_string
     end
-  end 
+  end
 end

--- a/riemann-client.gemspec
+++ b/riemann-client.gemspec
@@ -1,0 +1,31 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'riemann/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = 'riemann-client'
+  spec.version       = Riemann::VERSION
+  spec.author        = 'Kyle Kingsbury'
+  spec.email         = 'aphyr@aphyr.com'
+  spec.summary       = 'Client for the distributed event system Riemann.'
+  spec.description   = 'Client for the distributed event system Riemann.'
+  spec.homepage      = 'https://github.com/aphyr/riemann-ruby-client'
+  spec.license       = 'MIT'
+  spec.platform      = Gem::Platform::RUBY
+
+  spec.files         = `git ls-files`.split($/)
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ['lib']
+  spec.has_rdoc      = true
+
+  spec.required_ruby_version = '>= 1.8.7'
+
+  spec.add_development_dependency 'bundler', '>= 1.3'
+  spec.add_development_dependency 'bacon'
+
+  spec.add_dependency 'beefcake', '>= 0.3.5'
+  spec.add_dependency 'trollop', '>= 1.16.2'
+  spec.add_dependency 'mtrc', '>= 0.0.4'
+end

--- a/spec/client.rb
+++ b/spec/client.rb
@@ -9,6 +9,7 @@ Bacon.summary_on_exit
 
 include Riemann
 
+INACTIVITY_TIME = 5
 
 def roundtrip_metric(m)
   @client_with_transport << {
@@ -161,28 +162,28 @@ describe "Riemann::Client (TCP transport)" do
   should 'survive inactivity' do
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive inactivity',
     })
 
-    sleep 5
+    sleep INACTIVITY_TIME
 
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive inactivity',
     }).ok.should.be.true
   end
 
   should 'survive local close' do
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive local close',
     }).ok.should.be.true
 
     @client.close
 
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive local close',
     }).ok.should.be.true
   end
 end
@@ -210,33 +211,33 @@ describe "Riemann::Client (UDP transport)" do
   should 'survive inactivity' do
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive UDP inactivity',
     })
-    @client['service = "test"'].first.state.should.equal 'warning'
+    @client['service = "survive UDP inactivity"'].first.state.should.equal 'warning'
 
-    sleep 5
+    sleep INACTIVITY_TIME
 
     @client_with_transport.<<({
       :state => 'ok',
-      :service => 'test',
+      :service => 'survive UDP inactivity',
     })
-    @client['service = "test"'].first.state.should.equal 'ok'
+    @client['service = "survive UDP inactivity"'].first.state.should.equal 'ok'
   end
 
   should 'survive local close' do
     @client_with_transport.<<({
       :state => 'warning',
-      :service => 'test',
+      :service => 'survive UDP local close',
     })
-    @client['service = "test"'].first.state.should.equal 'warning'
+    @client['service = "survive UDP local close"'].first.state.should.equal 'warning'
 
     @client.close
 
     @client_with_transport.<<({
       :state => 'ok',
-      :service => 'test',
+      :service => 'survive UDP local close',
     })
-    @client['service = "test"'].first.state.should.equal 'ok'
+    @client['service = "survive UDP local close"'].first.state.should.equal 'ok'
   end
 
   should "raise Riemann::Client::Unsupported exception on query" do


### PR DESCRIPTION
This should fix #17, all (refactored) tests pass on 1.9.3, 2.1.1, jruby-1.7.11, and rbx-2.2.6.

However when I started digging into the tests that led to all sorts of other issues that I have made separate commits for, feel free to let me know which of these you actually want, etc. This many changes make me very nervous, and I still need to try the new code in our project. Would like some confirmation that everything continues to run normally for people already using the client. 

Main changes:
 * use encoded strings everywhere instead of Beefcake Buffers
 * tests now split for TCP and UDP transport
    * some tests could not be shared because they way the original was testing was using the return value from the `<<` call so that only works with TCP transport... you should take a look and see if these should be changed to be consolidated or I screwed something up
 * `#connected?` methods are mutex locked and seemingly fixed (doesn't seem like they would have worked before?)
 * added `gemspec` and `Gemfile` to make my life easier for testing the various rubies
 * removed `Client#connect` since `tcp.connect` doesn't exist and no one was calling it