### PR TITLE
Client should yield self

### DIFF
--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -31,9 +31,8 @@ class Riemann::Client
     if block_given?
       begin
         yield self
-      rescue Object => err
+      ensure
         close
-        raise err
       end
     end
   end

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -29,8 +29,12 @@ class Riemann::Client
     @udp = UDP.new(@options)
     @tcp = TCP.new(@options)
     if block_given?
-      yield self
-      close
+      begin
+        yield self
+      rescue Object => err
+        close
+        raise err
+      end
     end
   end
 

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -28,7 +28,10 @@ class Riemann::Client
 
     @udp = UDP.new(@options)
     @tcp = TCP.new(@options)
-    yield self if block_given?
+    if block_given?
+      yield self
+      close
+    end
   end
 
   def host

--- a/lib/riemann/client.rb
+++ b/lib/riemann/client.rb
@@ -28,6 +28,7 @@ class Riemann::Client
 
     @udp = UDP.new(@options)
     @tcp = TCP.new(@options)
+    yield self if block_given?
   end
 
   def host

--- a/spec/client.rb
+++ b/spec/client.rb
@@ -36,6 +36,14 @@ end
 
 shared "a riemann client" do
 
+  should 'yield itself to given block' do
+    client = nil
+    Client.new(:host => RIEMANN_IP, :port => RIEMANN_PORT) do |c|
+      client = c
+    end
+    client.should.be.kind_of?(Client)
+  end
+
   should 'be connected after sending' do
     @client_with_transport.connected?.should.be falsey
     @client.connected?.should.be falsey

--- a/spec/client.rb
+++ b/spec/client.rb
@@ -14,6 +14,8 @@ Bacon.summary_on_exit
 include Riemann
 
 INACTIVITY_TIME = 5
+RIEMANN_IP = ENV["RIEMANN_IP"] || "127.0.0.1"
+RIEMANN_PORT = ENV["RIEMANN_PORT"] || 5555
 
 def roundtrip_metric(m)
   @client_with_transport << {
@@ -152,7 +154,7 @@ end
 
 describe "Riemann::Client (TCP transport)" do
   before do
-    @client = Client.new
+    @client = Client.new(:host => RIEMANN_IP, :port => RIEMANN_PORT)
     @client_with_transport = @client.tcp
     @expected_rate = 100
   end
@@ -205,7 +207,7 @@ end
 
 describe "Riemann::Client (UDP transport)" do
   before do
-    @client = Client.new
+    @client = Client.new(:host => RIEMANN_IP, :port => RIEMANN_PORT)
     @client_with_transport = @client.udp
     @expected_rate = 1000
   end

--- a/spec/client.rb
+++ b/spec/client.rb
@@ -42,6 +42,21 @@ shared "a riemann client" do
       client = c
     end
     client.should.be.kind_of?(Client)
+    client.should.not.be.connected
+  end
+
+  should 'close sockets if given a block that raises' do
+    client = nil
+    begin
+      Client.new(:host => RIEMANN_IP, :port => RIEMANN_PORT) do |c|
+        client = c
+        raise "The Boom"
+      end
+    rescue
+      # swallow the exception
+    end
+    client.should.be.kind_of?(Client)
+    client.should.not.be.connected
   end
 
   should 'be connected after sending' do


### PR DESCRIPTION
Small change to allow using the client with block syntax:
```ruby
    Riemann::Client.new do |c|
      c.tcp << {
        :state => 'ok',
        :service => 'test',
        :time => Time.now.to_i,
      }
    end
```

Also includes change to test suite to allow specifying an alternate host/ip and port via env vars to support testing against a riemann running somewhere besides localhost/std port (eg: vm, container).

```
RIEMANN_IP=192.168.0.42 RIEMANN_PORT=12345 bundle exec spec/client.rb
```